### PR TITLE
Fix modular arithmetic

### DIFF
--- a/src/main.mo
+++ b/src/main.mo
@@ -16,14 +16,13 @@ let N = 10;
 //
 // Immutable, all operations return new objects.
 class ModularNumber (i : Int) = {
-    func addMultipleOfNUntilNonNegative(i : Int) : Int {
-        var j = i;
-        while (j < 0) {
-           j += N;
-        };
-        j
+    // The % operator is weird: it returns a negative output when the input is negative.
+    // Hence we wrap it into a function
+    func moduloN(i : Int) : Nat {
+        let j = i%N;
+        Int.abs(if (j < 0) { j+N } else { j })
     };
-  var val : Nat = Int.abs(addMultipleOfNUntilNonNegative(i)% N); // The actual number. We will maintain as invariant that it should be inside [0, N).
+  var val : Nat = moduloN(i); // The actual number. We will maintain as invariant that it should be inside [0, N).
   public func get() : Nat {
      val
   };

--- a/src/main.mo
+++ b/src/main.mo
@@ -77,9 +77,15 @@ actor {
         };
     };
 
-    type State = (Principal, Nat, Nat);
-    public query func getState() : async [State] {
+    // Objects of type 'ModularNumber' cannot be serialized because they contain functions,
+    // so we need to map them to Nat.
+    type SingleUserState = { user:Principal; x:Nat; y:Nat; };
+    public query func getState() : async [SingleUserState] {
 
-        Iter.toArray<State>(Iter.map<(Principal, Pos), State>(func(user : Principal, pos : Pos) : State { (user, pos.x.get(), pos.y.get() ) }, state.iter()))
+        Iter.toArray<SingleUserState>(
+            Iter.map<(Principal, Pos), SingleUserState>(
+                func(u : Principal, pos : Pos) : SingleUserState { {user=u; x=pos.x.get(); y=pos.y.get(); } },
+                state.iter())
+        )
     };
 };

--- a/src/main.mo
+++ b/src/main.mo
@@ -7,21 +7,18 @@ import Prelude "mo:base/Prelude";
 import Int "mo:base/Int";
 //import Error "mo:base/Error";
 
-
 let N = 10;
-
-
 
 // A member of Z/NZ for the above-defined N.
 //
 // Immutable, all operations return new objects.
 class ModularNumber (i : Int) = {
-    // The % operator is weird: it returns a negative output when the input is negative.
-    // Hence we wrap it into a function
-    func moduloN(i : Int) : Nat {
-        let j = i%N;
-        Int.abs(if (j < 0) { j+N } else { j })
-    };
+  // The % operator is weird: it returns a negative output when the input is negative.
+  // Hence we wrap it into a function
+  func moduloN(i : Int) : Nat {
+    let j = i%N;
+    Int.abs(if (j < 0) { j+N } else { j })
+  };
   var val : Nat = moduloN(i); // The actual number. We will maintain as invariant that it should be inside [0, N).
   public func get() : Nat {
      val
@@ -29,13 +26,10 @@ class ModularNumber (i : Int) = {
   public func add(delta : Int) : ModularNumber {
       ModularNumber ( val + delta)
   };
-
 };
-
 
 type Pos = { x : ModularNumber; y : ModularNumber };
 type Direction = { #left; #right; #up; #down };
-
 
 func principalEq(x: Principal, y: Principal) : Bool = x == y;
 
@@ -81,7 +75,6 @@ actor {
     // so we need to map them to Nat.
     type SingleUserState = { user:Principal; x:Nat; y:Nat; };
     public query func getState() : async [SingleUserState] {
-
         Iter.toArray<SingleUserState>(
             Iter.map<(Principal, Pos), SingleUserState>(
                 func(u : Principal, pos : Pos) : SingleUserState { {user=u; x=pos.x.get(); y=pos.y.get(); } },


### PR DESCRIPTION
Before this PR, the wrapping of position from -1 to N-1 did not work. This PR introduces type ModularNumber that fixes that.

## Testing

```
dfx build --skip-frontend && dfx canister install maze --mode=reinstall && dfx canister call maze join && dfx canister call maze getState
```

Then, did a number of
```
dfx canister call maze move '(variant{up})' && dfx canister call maze getState
```

Until the wrapping behavior is observed.