### PR TITLE
Handle walls

### DIFF
--- a/src/main.mo
+++ b/src/main.mo
@@ -92,8 +92,8 @@ type Direction = { #left; #right; #up; #down };
 func principalEq(x: Principal, y: Principal) : Bool = x == y;
 
 actor {
-    flexible let state = H.HashMap<Principal, Pos>(3, principalEq, Principal.hash);
-    flexible var map = parseMaze(MAZE_INPUT);
+    let state = H.HashMap<Principal, Pos>(3, principalEq, Principal.hash);
+    var map = parseMaze(MAZE_INPUT);
     
     public shared(msg) func join() : async Principal {
         let id = msg.caller;

--- a/src/main.mo
+++ b/src/main.mo
@@ -143,11 +143,6 @@ actor {
 
     // Returns a multi-line string showing th whole maze with the position of each player
     public query func plotMaze() : async Text {
-    //    var rendered = "";
-    //    for (row in map) {
-    //        for ()
-    //        rendered.append('\n');
-    //    }
     Array.foldl<Text, Text>(
         func (a: Text, b:Text) : Text { a # "\n" # b},
         "",


### PR DESCRIPTION
* Init maze by parsing a maze description
* Added debug function `plotMaze` plotting the maze with position of the players

## Follow up
* Distinguish the players. RIght now all of them are rendered as 'X' in the debug output.
* Make sure initial position of a player is in a free cell.

## Testing
I ran:
```
dfx build --skip-frontend && dfx canister install maze --mode=reinstall && dfx canister call maze ^Cin && dfx canister call maze getState
```

Then a few move and plot commands:
```
dfx canister call maze move '(variant{down})' && dfx canister call maze plotMaze
```

And it behaves as expected.